### PR TITLE
MNT: add joblib to the list of benchmarked projects

### DIFF
--- a/tests/full.yml
+++ b/tests/full.yml
@@ -32,3 +32,7 @@
       url: https://github.com/scikit-image/scikit-image
       asv_config: asv.conf.json
       package: skimage
+    - project: joblib
+      url: https://github.com/pierreglaser/joblib_benchmarks
+      asv_config: asv.conf.json
+      package: joblib


### PR DESCRIPTION
I simply changed `full.yml` to include the necessary metadata to run `joblib`'s benchmarks