### PR TITLE
Uncomment distributed tests

### DIFF
--- a/tests/full.yml
+++ b/tests/full.yml
@@ -19,11 +19,11 @@
       asv_config: dask/asv.conf.json
       package: dask
       results: dask/.asv/html/
-    # - project: distributed
-    #   url: https://github.com/dask/dask-benchmarks
-    #   asv_config: distributed/asv.conf.json
-    #   package: distributed
-    #   results: distributed/.asv/html
+    - project: distributed
+      url: https://github.com/dask/dask-benchmarks
+      asv_config: distributed/asv.conf.json
+      package: distributed
+      results: distributed/.asv/html
     - project: pymc3
       url: https://github.com/pymc-devs/pymc3
       asv_config: benchmarks/asv.conf.json


### PR DESCRIPTION
I see the distributed benchmarks were commented out in https://github.com/asv-runner/asv-runner/commit/74e575d08069986553f32d4861585d755c5e5b79 because they were failing at the time. Is this still the case, or does https://github.com/dask/dask-benchmarks/pull/26 fix the failures here?