### PR TITLE
Add trailing '/' to distributed results

### DIFF
--- a/tests/full.yml
+++ b/tests/full.yml
@@ -23,7 +23,7 @@
       url: https://github.com/dask/dask-benchmarks
       asv_config: distributed/asv.conf.json
       package: distributed
-      results: distributed/.asv/html
+      results: distributed/.asv/html/
     - project: pymc3
       url: https://github.com/pymc-devs/pymc3
       asv_config: benchmarks/asv.conf.json


### PR DESCRIPTION
This is a shot in the dark, but I noticed all the other projects have a trailing "/" character on their results location. 

xref https://github.com/asv-runner/asv-runner/pull/8#issuecomment-565589522